### PR TITLE
Make docker image smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.7
+FROM python:3.7-alpine
 
-RUN pip install kubernetes
+RUN pip install --no-cache-dir kubernetes
 
 COPY dask-worker-cull.py /opt/dask-worker-cull.py
 


### PR DESCRIPTION
- Use alpine python base image, much smaller than default
  based on debian
- Pass --no-cache-dir to pip, so it does not store built
  wheels