### PR TITLE
Automatically tag docker images with git sha1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# Get image tag from current git head
+TAG := $(shell git rev-parse --short HEAD)
+IMAGE = costrouc/dask-worker-cull
+
 dask-worker-cull:
-	docker build -t costrouc/dask-worker-cull:0.3 .
-	docker push costrouc/dask-worker-cull:0.3
+	docker build -t $(IMAGE):$(TAG) .
+	docker push $(IMAGE):$(TAG)


### PR DESCRIPTION
- Allows overriding name of the docker image built
- Automatically specifies a sha that matches the current checked
  out commit. This helps us track an image back to its source.